### PR TITLE
Add ability to specify allocation size limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,28 @@ end
 
 In some cases, the Ruby garbage collector will close IOs. In the above case, it's possible to just writing `IO.pipe` will not leak, as Ruby will garbage collect the resulting IOs immediately. It's still incorrect to not correctly close IOs, so don't depend on this behaviour.
 
+### Allocations
+
+Allocating large amounts of objects can lead to memery problems. `Async::RSpec::Memory` adds a `limit_allocations` matcher, which tracks the number of allocations and memory size for each object type and allows you to specify expected limits.
+
+```ruby
+RSpec.describe "memory allocations" do
+	include_context Async::RSpec::Memory
+	
+	it "limits allocation counts" do
+		expect do
+			6.times{String.new}
+		end.to limit_allocations(String => 10) # 10 strings can be allocated
+	end
+
+	it "limits allocation size" do
+		expect do
+			6.times{String.new("foo")}
+		end.to limit_allocations(size: 1024) # 1KB can be allocated
+	end
+end
+```
+
 ### Reactor
 
 Many specs need to run within a reactor. A shared context is provided which includes all the relevant bits, including the above leaks checks.

--- a/lib/async/rspec/memory.rb
+++ b/lib/async/rspec/memory.rb
@@ -100,8 +100,9 @@ module Async
 			class LimitAllocations
 				include ::RSpec::Matchers::Composable
 				
-				def initialize(allocations)
+				def initialize(size: nil, **allocations)
 					@allocations = allocations
+          @size = size
 					@errors = []
 				end
 				
@@ -125,6 +126,12 @@ module Async
 								@errors << "allocated #{allocation.count} instances (#{allocation.size} bytes) of #{klass}, expected at most #{acceptable}"
 							end
 						end
+					end
+					
+          total_allocated = trace.allocated.values.map(&:size).inject(0, :+)
+					
+					if @size && total_allocated > @size
+						@errors << "allocated #{total_allocated} bytes in total, expected within #{@size} bytes"
 					end
 					
 					return @errors.empty?

--- a/spec/async/rspec/memory_spec.rb
+++ b/spec/async/rspec/memory_spec.rb
@@ -23,22 +23,28 @@ RSpec.describe "memory context" do
 	
 	if Async::RSpec::Memory::Trace.supported?
 		# The following fails:
-		it "should exceed specified limit", pending: 'it should fail' do
+		it "should exceed specified count limit", pending: 'it should fail' do
 			expect do
 				6.times{String.new}
 			end.to limit_allocations(String => 4)
 		end
 	end
 	
-	it "should not exceed specified limit" do
+	it "should not exceed specified count limit" do
 		expect do
 			2.times{String.new}
 		end.to limit_allocations(String => 4)
 	end
 	
-	it "should be within specified range" do
+	it "should be within specified count range" do
 		expect do
 			2.times{String.new}
 		end.to limit_allocations(String => 1..3)
+	end
+	
+	it "should not exceed specified size limit" do
+		expect do
+			"a" * 100_000
+		end.to limit_allocations(size: 101_000)
 	end
 end


### PR DESCRIPTION
Sometimes it's not important how many objects are allocated, but how much memory in bytes is being allocated. For now it's only possible to limit the total memory allocated for all objects, even though we're internally tracking it per object type.

This matcher is useful when dealing with large streams of data, for example accepting large file uploads, and you want to assert that you're keeping memory usage low with diligent string object management.

While here, I also added documentation of `Async::RSpec::Memory` to the README.