### PR TITLE
Rewrite allocation size matchers to actually work with counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,17 @@ RSpec.describe "memory allocations" do
 			6.times{String.new}
 		end.to limit_allocations(String => 10) # 10 strings can be allocated
 	end
-
+	
+	it "limits allocation counts (hash)" do
+		expect do
+			6.times{String.new}
+		end.to limit_allocations(String => { count: 10 }) # 10 strings can be allocated
+	end
+	
 	it "limits allocation size" do
 		expect do
 			6.times{String.new("foo")}
-		end.to limit_allocations(size: 1024) # 1KB can be allocated
+		end.to limit_allocations(String => { size: 1024 }) # 1 KB of strings can be allocated
 	end
 end
 ```

--- a/spec/async/rspec/memory_spec.rb
+++ b/spec/async/rspec/memory_spec.rb
@@ -34,17 +34,25 @@ RSpec.describe "memory context" do
 		expect do
 			2.times{String.new}
 		end.to limit_allocations(String => 4)
+		
+		expect do
+			2.times{String.new}
+		end.to limit_allocations(String => { count: 4 })
 	end
 	
 	it "should be within specified count range" do
 		expect do
 			2.times{String.new}
 		end.to limit_allocations(String => 1..3)
+
+		expect do
+			2.times{String.new}
+		end.to limit_allocations(String => { count: 1..3 })
 	end
 	
 	it "should not exceed specified size limit" do
 		expect do
 			"a" * 100_000
-		end.to limit_allocations(size: 101_000)
+		end.to limit_allocations(String => { size: 101_000 })
 	end
 end


### PR DESCRIPTION
Previously the allocation size matcher looked like this (added in https://github.com/socketry/async-rspec/pull/2):

```rb
expect { ... }.to limit_allocations(size: 100_000)
```

However, that caused some difficulties in extracting parameters, because we cannot use keyword arguments, due to keys not having to be symbols (they are classes with counts). So I rewrote the API to be:

```rb
expect { ... }.to limit_allocations(String => { size: 100_000 })
```

For consistency, it's also now possible to explicitly specify that you're limiting counts:

```rb
expect { ... }.to limit_allocations(String => { count: 10 })
expect { ... }.to limit_allocations(String => 10)
```

I think this API makes much more sense, because it maps nicely to the allocations that we're storing internally, i.e. for each object type we're tracking allocation count and size.