### PR TITLE
CI: Remove 2.4 from matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ cache: bundler
 
 matrix:
   include:
-    - rvm: 2.4
     - rvm: 2.5
     - rvm: 2.6
     - rvm: 2.7


### PR DESCRIPTION
The Ruby support schedule has EOL'd 2.4 https://www.ruby-lang.org/en/downloads/branches/