### PR TITLE
Avoid "shadowing outer local variable - spec_task"

### DIFF
--- a/lib/async/rspec/reactor.rb
+++ b/lib/async/rspec/reactor.rb
@@ -53,8 +53,8 @@ module Async
 				reactor.run do |task|
 					task.annotate(self.class)
 					
-					spec_task = task.async do |spec_task|
-						spec_task.annotate("running example")
+					spec_task = task.async do |the_spec_task|
+						the_spec_task.annotate("running example")
 						
 						result = yield
 						


### PR DESCRIPTION
## Description

This PR attempts to avoid a Ruby warning being emitted.

The warning looked like this:

    gems/async-rspec-1.16.0/lib/async/rspec/reactor.rb:56: warning: shadowing outer local variable - spec_task


### Types of Changes

- Maintenance.

### Testing


- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [ ] I tested my changes in staging.
- [ ] I tested my changes in production.
