### PR TITLE
CI: Remove Ruby 2.5 (EOL) from matrix

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -14,10 +14,9 @@ jobs:
           - macos
         
         ruby:
-          - 2.5
           - 2.6
           - 2.7
-          - 3.0
+          - "3.0"
         
         experimental: [false]
         env: [""]


### PR DESCRIPTION


## Description

This PR drops Ruby 2.5 from builds.

(Quotes around 3.0 avoid YAML conversion issue.)

### Types of Changes

- Maintenance.

### Testing

Just ran CI.
