### PR TITLE
Require rspec before rspec/files

### DIFF
--- a/lib/async/rspec/leaks.rb
+++ b/lib/async/rspec/leaks.rb
@@ -18,6 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+require 'rspec'
 require 'rspec/files'
 
 module Async


### PR DESCRIPTION
Requiring `rspec/files` without requiring `rspec` raises an error:
```
irb(main):001:0> require 'rspec/files'
/home/user/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-files-1.1.1/lib/rspec/files/leaks.rb:39:in `<module:Files>': undefined method `shared_context' for RSpec:Module (NoMethodError)

                RSpec.shared_context Leaks do
                     ^^^^^^^^^^^^^^^
        from /home/user/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-files-1.1.1/lib/rspec/files/leaks.rb:22:in `<module:RSpec>'
        from /home/user/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-files-1.1.1/lib/rspec/files/leaks.rb:21:in `<top (required)>'
        from /home/user/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-files-1.1.1/lib/rspec/files.rb:22:in `require_relative'
        from /home/user/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-files-1.1.1/lib/rspec/files.rb:22:in `<top (required)>'
        from (irb):1:in `require'
        from (irb):1:in `<main>'
        from /home/user/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/irb-1.4.1/exe/irb:11:in `<top (required)>'
        from /home/user/.asdf/installs/ruby/3.1.2/bin/irb:25:in `load'
        from /home/user/.asdf/installs/ruby/3.1.2/bin/irb:25:in `<top (required)>'
        from /home/user/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.14/lib/bundler/cli/exec.rb:58:in `load'
        from /home/user/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.14/lib/bundler/cli/exec.rb:58:in `kernel_load'
        from /home/user/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.14/lib/bundler/cli/exec.rb:23:in `run'
        from /home/user/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.14/lib/bundler/cli.rb:483:in `exec'
        from /home/user/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.14/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
        from /home/user/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.14/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
        from /home/user/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.14/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
        ... 8 levels...
```

Apparently I faced some very edge case, but I tried to migrate my project on using bootsnap and spring to speedup it's boot times, and found out that spring may load async-rspec before rspec which leads to an error similar to the one above. Removing boosnap does not help, but removing async-rspec makes rspec start without errors. 

<!--
What changes are being made? What problem are you solving?
What feature/bug is being fixed here?
If this is an aesthetic change, please include screenshots.
-->

### Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

### Testing

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [ ] I tested my changes in staging.
- [ ] I tested my changes in production.
