### PR TITLE
fix: copy over rspec context to reactor thread

### DIFF
--- a/lib/async/rspec/reactor.rb
+++ b/lib/async/rspec/reactor.rb
@@ -78,6 +78,7 @@ module Async
 			include Reactor
 			let(:reactor) {@reactor}
 			
+			rspec_context = Thread.current[:__rspec]
 			include_context Async::RSpec::Leaks
 			
 			around(:each) do |example|
@@ -90,6 +91,7 @@ module Async
 						task.annotate(self.class)
 						
 						run_in_reactor(@reactor, duration) do
+							Thread.current[:__rspec] = rspec_context
 							example.run
 						end
 					ensure

--- a/spec/async/rspec/reactor_spec.rb
+++ b/spec/async/rspec/reactor_spec.rb
@@ -82,4 +82,13 @@ RSpec.describe Async::RSpec::Reactor do
 		# 	end.to raise_error("Boom!")
 		# end
 	end
+
+	context "rspec metadata", timeout: 1 do
+		include_context Async::RSpec::Reactor	
+
+		it "should have access to example metadata" do
+			expect(RSpec.current_example).not_to be_nil
+			expect(RSpec.current_example.metadata[:described_class]).to eq(Async::RSpec::Reactor)
+		end
+	end
 end


### PR DESCRIPTION
We were running into some issues using async-rspec in specs that were trying to access spec metadata. 

In our case, we're using a [rspec-snapshot](https://github.com/levinmr/rspec-snapshot) to let us match against snapshots, which [uses the spec metadata](https://github.com/levinmr/rspec-snapshot/blob/master/lib/rspec/snapshot/matchers.rb#L10) to construct a directory path to load snapshots from. When we initialize said matcher in a spec example running inside the reactor, that metadata is nil, since it's stored as a thread-local variable.

The workaround here is just copying over the RSpec thread-local variables into the reactor block.

## Types of Changes

- Bug fix.

## Contribution

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
